### PR TITLE
feat: Add C++ implementation for 07_UDP

### DIFF
--- a/src/07_UDP/UDP_client.cpp
+++ b/src/07_UDP/UDP_client.cpp
@@ -1,0 +1,151 @@
+// Simple UDP client: send a file in fixed-size chunks to a UDP server and wait for ACKs
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <cstring>      // For memset, strncmp, strerror
+#include <sys/socket.h> // For socket, sendto, recvfrom
+#include <netinet/in.h> // For sockaddr_in, htons
+#include <arpa/inet.h>  // For inet_pton
+#include <unistd.h>     // For close()
+#include <sys/time.h>   // For struct timeval
+
+#define SERVER_PORT 9876
+#define BUFFER_SIZE 1024
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <file-to-send> [server-ip]" << std::endl;
+        return 1;
+    }
+
+    const char *filename = argv[1];
+    const char *server_ip = (argc >= 3) ? argv[2] : "127.0.0.1";
+
+    std::ifstream input_file(filename, std::ios::binary);
+    if (!input_file.is_open()) {
+        std::cerr << "Error: Could not open file '" << filename << "' for reading" << std::endl;
+        return 1;
+    }
+
+    int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (sockfd < 0) {
+        std::cerr << "Error: socket() failed: " << strerror(errno) << std::endl;
+        return 1;
+    }
+
+    struct sockaddr_in server_addr;
+    std::memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(SERVER_PORT);
+    if (inet_pton(AF_INET, server_ip, &server_addr.sin_addr) != 1) {
+        std::cerr << "Error: invalid server IP '" << server_ip << "'" << std::endl;
+        close(sockfd);
+        return 1;
+    }
+
+    std::vector<char> buffer(BUFFER_SIZE);
+    const std::string end_message = "END";
+    const std::string ack_message = "ACK";
+
+    // Set receive timeout for ACKs
+    struct timeval tv;
+    tv.tv_sec = 2;  // 2 seconds
+    tv.tv_usec = 0;
+    if (setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0) {
+        std::cerr << "Warning: setsockopt SO_RCVTIMEO failed: " << strerror(errno) << std::endl;
+    }
+
+    socklen_t server_len = sizeof(server_addr);
+
+    const int max_retries = 5;
+
+    // Read file and send in chunks
+    while (input_file) {
+        input_file.read(buffer.data(), BUFFER_SIZE);
+        std::streamsize n = input_file.gcount();
+        if (n <= 0) break;
+
+        int retries = 0;
+        bool acked = false;
+        while (retries < max_retries && !acked) {
+            ssize_t sent = sendto(sockfd, buffer.data(), (size_t)n, 0,
+                                  (struct sockaddr *)&server_addr, server_len);
+            if (sent < 0) {
+                std::cerr << "Error: sendto failed: " << strerror(errno) << std::endl;
+                close(sockfd);
+                return 1;
+            }
+
+            // Wait for ACK
+            char ack_buf[16];
+            ssize_t r = recvfrom(sockfd, ack_buf, sizeof(ack_buf), 0, nullptr, nullptr);
+            if (r > 0) {
+                if (r == (ssize_t)ack_message.length() &&
+                    std::strncmp(ack_buf, ack_message.c_str(), ack_message.length()) == 0) {
+                    acked = true;
+                    break;
+                }
+            } else {
+                // timeout or error
+                if (errno == EWOULDBLOCK || errno == EAGAIN) {
+                    retries++;
+                    std::cerr << "Warning: ACK timeout, retry " << retries << " for chunk" << std::endl;
+                    continue;
+                } else {
+                    std::cerr << "Warning: recvfrom error: " << strerror(errno) << std::endl;
+                    retries++;
+                    continue;
+                }
+            }
+        }
+
+        if (!acked) {
+            std::cerr << "Error: failed to receive ACK after " << max_retries << " retries" << std::endl;
+            close(sockfd);
+            return 1;
+        }
+    }
+
+    // Send END message
+    int end_retries = 0;
+    bool end_acked = false;
+    while (end_retries < max_retries && !end_acked) {
+        ssize_t sent = sendto(sockfd, end_message.c_str(), end_message.length(), 0,
+                              (struct sockaddr *)&server_addr, server_len);
+        if (sent < 0) {
+            std::cerr << "Error: sendto END failed: " << strerror(errno) << std::endl;
+            close(sockfd);
+            return 1;
+        }
+
+        char ack_buf[16];
+        ssize_t r = recvfrom(sockfd, ack_buf, sizeof(ack_buf), 0, nullptr, nullptr);
+        if (r > 0) {
+            if (r == (ssize_t)ack_message.length() &&
+                std::strncmp(ack_buf, ack_message.c_str(), ack_message.length()) == 0) {
+                end_acked = true;
+                break;
+            }
+        } else {
+            if (errno == EWOULDBLOCK || errno == EAGAIN) {
+                end_retries++;
+                std::cerr << "Warning: END ACK timeout, retry " << end_retries << std::endl;
+                continue;
+            } else {
+                end_retries++;
+                std::cerr << "Warning: recvfrom error on END: " << strerror(errno) << std::endl;
+                continue;
+            }
+        }
+    }
+
+    if (!end_acked) {
+        std::cerr << "Warning: no ACK for END after " << max_retries << " retries; continuing." << std::endl;
+    }
+
+    std::cout << "File '" << filename << "' sent." << std::endl;
+
+    close(sockfd);
+    return 0;
+}

--- a/src/07_UDP/UDP_server.cpp
+++ b/src/07_UDP/UDP_server.cpp
@@ -1,0 +1,85 @@
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <cstring>      // For memset, strncmp
+#include <sys/socket.h> // For socket, bind, recvfrom, sendto
+#include <netinet/in.h> // For sockaddr_in, htons, INADDR_ANY
+#include <unistd.h>     // For close()
+
+#define SERVER_PORT 9876
+#define BUFFER_SIZE 1024
+
+int main() {
+    int server_socket_fd;
+    struct sockaddr_in server_addr, client_addr;
+    socklen_t client_len = sizeof(client_addr);
+
+    // Create a UDP socket (AF_INET = IPv4, SOCK_DGRAM = UDP)
+    server_socket_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (server_socket_fd < 0) {
+        std::cerr << "Error: Could not create socket" << std::endl;
+        return 1;
+    }
+
+    // Set up the server address structure
+    std::memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(SERVER_PORT); // htons converts port to network byte order
+    server_addr.sin_addr.s_addr = INADDR_ANY; // Listen on all available interfaces
+
+    // Bind the socket to the server's address and port
+    if (bind(server_socket_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+        std::cerr << "Error: Could not bind socket" << std::endl;
+        close(server_socket_fd);
+        return 1;
+    }
+
+    std::cout << "Server is ready to receive files..." << std::endl;
+
+    // Open the output file in binary write mode
+    std::ofstream output_file("received.c", std::ios::binary);
+    if (!output_file.is_open()) {
+        std::cerr << "Error: Could not open output file" << std::endl;
+        close(server_socket_fd);
+        return 1;
+    }
+
+    std::vector<char> buffer(BUFFER_SIZE);
+    bool receivingFile = true;
+    const std::string end_message = "END";
+    const std::string ack_message = "ACK";
+
+    while (receivingFile) {
+        // Wait for a packet (blocking call)
+        ssize_t bytes_received = recvfrom(server_socket_fd, buffer.data(), BUFFER_SIZE, 0,
+                                          (struct sockaddr *)&client_addr, &client_len);
+
+        if (bytes_received < 0) {
+            std::cerr << "Error: recvfrom failed" << std::endl;
+            continue;
+        }
+
+        // Check if the packet contains the "END" message
+        if (bytes_received == (ssize_t)end_message.length() && 
+            std::strncmp(buffer.data(), end_message.c_str(), end_message.length()) == 0) 
+        {
+            std::cout << "File transfer completed." << std::endl;
+            receivingFile = false;
+        } else {
+            // Write the received data chunk to the file
+            output_file.write(buffer.data(), bytes_received);
+
+            // Send "ACK" back to the client to confirm receipt
+            sendto(server_socket_fd, ack_message.c_str(), ack_message.length(), 0,
+                   (struct sockaddr *)&client_addr, client_len);
+        }
+    }
+
+    // Clean up
+    output_file.close();
+    close(server_socket_fd);
+    std::cout << "File saved as received.c" << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request adds a C++ re-implementation of the existing 07_UDP Java demo, matching the Java server/client protocol (stop‑and‑wait UDP file transfer with an "END" sentinel and "ACK" responses).

Files added/modified (paths relative to repo root)

[UDP_server.cpp](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — UDP server: receives file chunks, writes to [received.c](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), sends "ACK" for each chunk, stops on receiving "END".
[UDP_client.cpp](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — UDP client: reads a local file and sends it in chunks to server, waits for "ACK" for each chunk (stop-and-wait). Usage: /tmp/UDP_client <file-to-send> [server-ip].

This change reimplements the Java logic in C++ and keeps the same protocol (port, buffer size, messages). Fixes #10

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I compiled and ran the C++ server and client and performed an end-to-end transfer. The server saved the transmitted file and its bytes matched the sent file.

Steps I ran (copy/paste):

Build:
g++ -std=c++17 -Wall -Wextra -O2 computer-networks/src/07_UDP/UDP_server.cpp -o /tmp/UDP_server
g++ -std=c++17 -Wall -Wextra -O2 computer-networks/src/07_UDP/UDP_client.cpp -o /tmp/UDP_client

Start server (background):
nohup /tmp/UDP_server > /tmp/udp_server.log 2>&1 &
# or run in a terminal to see stdout
Create a tiny test file:
echo -n '// test file\nint main(){return 0;}' > /home/soumya/send_test.c
Send file from client to server:
/tmp/UDP_client /home/soumya/send_test.c 127.0.0.1
Verify server wrote the file:
ls -l /home/soumya/received.c
od -c /home/soumya/received.c | sed -n '1,120p'
# Confirm contents match send_test.c

Results:

Both C++ programs compiled with g++ (C++17) using -Wall -Wextra and produced no warnings.

End-to-end transfer completed and [received.c](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) contains the same bytes as the sent file.

[x]Test A — Compilation: compiled both server and client with no warnings.

[x]Test B — End-to-end transfer: server received the file and saved it correctly.

**Test Configuration**:
OS: Linux (development environment used)
Shell: bash
Toolchain: g++ with C++17 (tested using system g++ with -std=c++17 -Wall -Wextra)
No special hardware or SDK required
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Information
Protocol parity: Both Java and C++ use port 9876, buffer size 1024, write raw chunk bytes to file, use END to signal end-of-transfer, and send ACK after each chunk. Behavior is equivalent.
Small differences:
The Java client hard-codes [main.c](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). The C++ client accepts a filename argument (usage: UDP_client <file> [server-ip]) — this is a small usability enhancement.
The C++ client implements receive timeouts and retry logic for ACKs (2s timeout, 5 retries). This makes the C++ client more robust on lossy networks but does not change the protocol semantics.
The C++ client attempts to receive an ACK for the final END message (and will continue if none arrives). The Java client does not explicitly wait for an END ACK. This difference is harmless; if exact byte-for-byte behavior is required, the C++ client can be adjusted to not wait for the END ACK.
No changes were made to the Java files (per request).